### PR TITLE
Fix typo in cmake.params: "cmake" -> "cmd"

### DIFF
--- a/lua/tasks/module/cmake.lua
+++ b/lua/tasks/module/cmake.lua
@@ -255,7 +255,7 @@ end
 cmake.params = {
   target = get_target_names,
   build_type = { 'Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel' },
-  'cmake',
+  'cmd',
   'dap_name',
 }
 cmake.condition = function() return Path:new('CMakeLists.txt'):exists() end


### PR DESCRIPTION
It seems there is a typo in the cmake.params table. I assume, instead of "cmake", the parameter should be "cmd".