### PR TITLE
Fix module search to include runtime

### DIFF
--- a/lua/tasks/utils.lua
+++ b/lua/tasks/utils.lua
@@ -60,14 +60,11 @@ end
 
 ---@return table
 function utils.get_module_names()
-  local module_dir = Path:new(debug.getinfo(1).source:sub(2)):parent() / 'module'
-
   local modules = {}
-  for _, entry in ipairs(scandir.scan_dir(module_dir.filename, { depth = 1 })) do
-    -- Strip full path and extension
-    local extension_len = 4
-    local parent_offset = 2
-    table.insert(modules, entry:sub(#Path:new(entry):parent().filename + parent_offset, #entry - extension_len))
+
+  local runtime_files = vim.api.nvim_get_runtime_file("lua/tasks/module/*.lua", true)
+  for _, file in ipairs(runtime_files) do
+    table.insert(modules, vim.fn.fnamemodify(file, ":t:r"))
   end
 
   return modules

--- a/lua/tasks/utils.lua
+++ b/lua/tasks/utils.lua
@@ -1,5 +1,3 @@
-local scandir = require('plenary.scandir')
-local Path = require('plenary.path')
 local utils = {}
 
 local args_regex = vim.regex([[\s\%(\%([^'"]*\(['"]\)[^'"]*\1\)*[^'"]*$\)\@=]])
@@ -62,9 +60,9 @@ end
 function utils.get_module_names()
   local modules = {}
 
-  local runtime_files = vim.api.nvim_get_runtime_file("lua/tasks/module/*.lua", true)
+  local runtime_files = vim.api.nvim_get_runtime_file('lua/tasks/module/*.lua', true)
   for _, file in ipairs(runtime_files) do
-    table.insert(modules, vim.fn.fnamemodify(file, ":t:r"))
+    table.insert(modules, vim.fn.fnamemodify(file, ':t:r'))
   end
 
   return modules


### PR DESCRIPTION
When using `auto`, the current implementation does not take into account modules that one might include in their own config. This PR fixes the problem performing a runtime-wide search for files in `lua/tasks/module/`.