### PR TITLE
fix: don't try to encode dap_open_command in JSON

### DIFF
--- a/lua/tasks/project_config.lua
+++ b/lua/tasks/project_config.lua
@@ -23,7 +23,10 @@ end
 --- Writes all values as JSON to disk.
 function ProjectConfig:write()
   local params_file = Path:new(config.params_file)
+  local tmp_dap_open_command = self.dap_open_command
+  self.dap_open_command = nil
   params_file:write(vim.json.encode(self), 'w')
+  self.dap_open_command = tmp_dap_open_command
 end
 
 return ProjectConfig


### PR DESCRIPTION
`dap_open_command` is a function, and Neovim gets *very* angry when asked
to encode a function in JSON. I don't know if it silently allowed this
before or what, but it's causing issues for me.

This just temporarily stores it, clears it in the project config while
encoding, and then puts it back. Simple enough.

