### PR TITLE
Fix input prompt not having whitespace

### DIFF
--- a/lua/tasks/init.lua
+++ b/lua/tasks/init.lua
@@ -63,7 +63,7 @@ function tasks.set_module_param(module_type, param_name)
   if not param then
     if vim.tbl_contains(module.params, param_name) then
       -- Contains a string without a value, request for input
-      vim.ui.input({ prompt = string.format('Set "%s" for module "%s"', param_name, module_name), default = current_value }, function(input)
+      vim.ui.input({ prompt = string.format('Set "%s" for module "%s": ', param_name, module_name), default = current_value }, function(input)
         project_config[module_name][param_name] = input
         project_config:write()
       end)

--- a/lua/tasks/module/cmake.lua
+++ b/lua/tasks/module/cmake.lua
@@ -27,7 +27,7 @@ local function get_reply_dir(build_dir) return build_dir / '.cmake' / 'api' / 'v
 ---@return table
 local function get_target_info(codemodel_target, reply_dir) return vim.json.decode((reply_dir / codemodel_target['jsonFile']):read()) end
 
---- Creates query files that to acess information about targets after CMake configuration.
+--- Creates query files to access information about targets after CMake configuration.
 ---@param build_dir table
 ---@return boolean: Returns `true` on success.
 local function make_query_files(build_dir)

--- a/lua/tasks/runner.lua
+++ b/lua/tasks/runner.lua
@@ -1,5 +1,6 @@
 local config = require('tasks.config')
 local Job = require('plenary.job')
+local utils = require('tasks.utils')
 local runner = {}
 
 local last_job
@@ -131,6 +132,11 @@ function runner.chain_commands(task_name, commands, module_config, addition_args
       end
       last_job = dap
     end)
+    return
+  end
+
+  if vim.fn.executable(command.cmd) == 0 then
+    utils.notify(string.format('Command "%s" is not executable', command.cmd), vim.log.levels.ERROR)
     return
   end
 


### PR DESCRIPTION
When running `set_module_param`, this PR changes the prompt from

`Set "cmd" for module "cmake"cmake` (no space, hard to read)

to

`Set "cmd" for module "cmake": cmake`.

It also returns early if the current `cmd` is not executable to avoid unnecessarily long error messages printed by plenary.job.