### PR TITLE
Support new dap multi config setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+# Neovim
+.emmyrc.json
 Session.vim
+
+# Nix
+.envrc
+.direnv/

--- a/README.md
+++ b/README.md
@@ -56,61 +56,68 @@ To configure the plugin, you can call `require('tasks').setup(values)`, where `v
 ```lua
 local Path = require('plenary.path')
 require('tasks').setup({
-    default_params = { -- Default module parameters with which `neovim.json` will be created.
-      cmake = {
-        cmd = 'cmake', -- CMake executable to use, can be changed using `:Task set_module_param cmake cmd`.
-        build_type = 'Debug', -- Build type, can be changed using `:Task set_module_param cmake build_type`.
-        build_kit = 'default', -- default build kit, can be changed using `:Task set_module_param cmake build_kit`.
-        dap_name = 'codelldb', -- DAP configuration name from `require('dap').configurations`. If there is no such configuration, a new one with this name as `type` will be created.
-        build_dir = tostring(Path:new('{cwd}', 'build', '{build_kit}', '{build_type}')), -- Build directory. The expressions `{cwd}`, `{build_kit}` and `{build_type}` will be expanded with the corresponding text values. Could be a function that return the path to the build directory.
-        cmake_kits_file = nil, -- set path to JSON file containing cmake kits
-        cmake_build_types_file = nil, -- set path to JSON file containing cmake kits
-        clangd_cmdline = {
-          'clangd',
-          '--background-index',
-          '--clang-tidy',
-          '--header-insertion=never',
-          '--completion-style=detailed',
-          '--offset-encoding=utf-8',
-          '-j=4',
-        }, -- command line for invoking clangd - this array will be extended with --compile-commands-dir and --query-driver after each cmake configure with parameters inferred from build_kit, build_type and build_dir
-        ignore_presets = false, -- if true, cmake presets will not be used, build_kit and build_type will be used instead even if CMakePresets.json or CMakeUserPresets.json files are present in the project root.
-        restart_clangd_after_configure = true, -- if true, clangd will be restarted after each cmake configure with updated compile_commands.json file and --query-driver parameters mattching current cmake build_kit and build_type or build_preset.
+  default_params = { -- Default module parameters with which `neovim.json` will be created.
+    cmake = {
+      cmd = 'cmake', -- CMake executable to use, can be changed using `:Task set_module_param cmake cmd`.
+      build_type = 'Debug', -- Build type, can be changed using `:Task set_module_param cmake build_type`.
+      build_kit = 'default', -- default build kit, can be changed using `:Task set_module_param cmake build_kit`.
+      dap = {
+        config = 'cpp', -- DAP language configurations from `require('dap').configurations`. If there are no such configurations, a new one will be created.
+        name = 'codelldb', -- DAP configuration name from `require('dap').configurations[config]`. If there is no such configuration a new one with this name as `type` will be created.
       },
-      bazel = {
-        cmd = 'bazel',
-        dap_name = 'codelldb',
+      build_dir = tostring(Path:new('{cwd}', 'build', '{build_kit}', '{build_type}')), -- Build directory. The expressions `{cwd}`, `{build_kit}` and `{build_type}` will be expanded with the corresponding text values. Could be a function that return the path to the build directory.
+      cmake_kits_file = nil, -- set path to JSON file containing cmake kits
+      cmake_build_types_file = nil, -- set path to JSON file containing cmake kits
+      clangd_cmdline = {
+        'clangd',
+        '--background-index',
+        '--clang-tidy',
+        '--header-insertion=never',
+        '--completion-style=detailed',
+        '--offset-encoding=utf-8',
+        '--pch-storage=memory',
+        '--cross-file-rename',
+        '-j=4',
+      }, -- command line for invoking clangd - this array will be extended with --compile-commands-dir and --query-driver after each cmake configure with parameters inferred from build_kit, build_type and build_dir
+    },
+    zig = {
+      cmd = 'zig', -- zig command which will be invoked
+      dap = {
+        config = 'zig', -- DAP language configurations from `require('dap').configurations`. If there are no such configurations, a new one will be created.
+        name = 'codelldb', -- DAP configuration name from `require('dap').configurations[config]`. If there is no such configuration a new one with this name as `type` will be created.
       },
-      zig = {
-        cmd = 'zig', -- zig command which will be invoked
-        dap_name = 'codelldb', -- DAP configuration name from `require('dap').configurations`. If there is no such configuration, a new one with this name as `type` will be created.
-        build_type = 'Debug', -- build type, can be changed using `:Task set_module_param zig build_type`
-        build_step = 'install', -- build step, cah be changed using `:Task set_module_param zig build_step`
-      },
-      cargo = {
-        dap_name = 'codelldb', -- DAP configuration name from `require('dap').configurations`. If there is no such configuration, a new one with this name as `type` will be created.
-      },
-      npm = {
-        cmd = 'npm', -- npm command which will be invoked. If using yarn or pnpm, change here.
-        working_directory = vim.loop.cwd(), -- working directory in which NPM will be invoked
-      },
-      make = {
-        cmd = 'make', -- make command which will be invoked
-        args = {
-          all = { '-j10', 'all' }, -- :Task start make all   → make -j10 all
-          build = {}, -- :Task start make build → make
-          nuke = { 'clean' }, -- :Task start make nuke  → make clean
-        },
+      build_type = 'Debug', -- build type, can be changed using `:Task set_module_param zig build_type`
+      build_step = 'install', -- build step, cah be changed using `:Task set_module_param zig build_step`
+    },
+    cargo = {
+      dap = {
+        config = 'rust', -- DAP language configurations from `require('dap').configurations`. If there are no such configurations, a new one will be created.
+        name = 'codelldb', -- DAP configuration name from `require('dap').configurations[config]`. If there is no such configuration a new one with this name as `type` will be created.
       },
     },
-    save_before_run = true,
-    params_file = 'neovim.json',
-    quickfix = {
-      pos = 'botright',
-      height = 12,
-      only_on_error = false,
+    npm = {
+      cmd = 'npm', -- npm command which will be invoked. If using yarn or pnpm, change here.
+      working_directory = vim.loop.cwd(), -- working directory in which NPM will be invoked
     },
-    dap_open_command = function() return require('dap').repl.open() end,
+    make = {
+      cmd = 'make', -- make command which will be invoked
+      args = {
+        all = { '-j10', 'all' }, -- :Task start make all   → make -j10 all
+        build = {}, -- :Task start make build → make
+        nuke = { 'clean' }, -- :Task start make nuke  → make clean
+      },
+    },
+  },
+  save_before_run = true,
+  params_file = 'neovim.json',
+  quickfix = {
+    pos = 'botright',
+    height = 12,
+    only_on_error = false,
+  },
+  dap_open_command = function() return require('dap').repl.open() end,
+})
+
 ```
 
 # Usage examples
@@ -530,11 +537,14 @@ To create a module just put a lua file under `lua/tasks/module` in your configur
     -- A table of module tasks. Possible values:
     task_name1 = {
       -- Required parameters:
-      cmd = 'command' -- Command to execute.
+      cmd = 'command', -- Command to execute.
       -- Optional parameters:
-      cwd = 'directory' -- Command working directory. Default to current working directory.
+      cwd = 'directory', -- Command working directory. Default to current working directory.
       after_success = callback -- A callback to execute on success.
-      dap_name = 'dap_name' -- A debug adapter name. If exists, the task will be launched through the adapter. Usually taken from a module parameter. Implies ignoring all streams below.
+      dap = {
+        config = 'dap_config', -- Type of the debug configuration.
+        name = 'dap_name', -- The name of the specific config of the configuration type to use. If exists, the task will be launched through the adapter. Usually taken from a module parameter. Implies ignoring all streams below.
+      },
       -- Disable a stream output to quickfix. If both are disabled, quickfix will not show up. If you want to capture output of a stream in a next task, you need to disable it.
       ignore_stdout = true,
       ignore_stderr = true,

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774106199,
+        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "A Nix-flake-based C/C++ development environment";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, ... }@inputs:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSupportedSystem =
+        f:
+        inputs.nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            pkgs = import inputs.nixpkgs { inherit system; };
+          }
+        );
+    in
+    {
+      devShells = forEachSupportedSystem (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              lua5_5_compat
+              emmylua-ls
+              stylua
+            ];
+          };
+        }
+      );
+    };
+}

--- a/lua/tasks/config.lua
+++ b/lua/tasks/config.lua
@@ -7,7 +7,10 @@ local config = {
         cmd = 'cmake', -- CMake executable to use, can be changed using `:Task set_module_param cmake cmd`.
         build_type = 'Debug', -- Build type, can be changed using `:Task set_module_param cmake build_type`.
         build_kit = 'default', -- default build kit, can be changed using `:Task set_module_param cmake build_kit`.
-        dap_name = 'codelldb', -- DAP configuration name from `require('dap').configurations`. If there is no such configuration, a new one with this name as `type` will be created.
+        dap = {
+          config = 'cpp', -- DAP language configurations from `require('dap').configurations`. If there are no such configurations, a new one will be created.
+          name = 'codelldb', -- DAP configuration name from `require('dap').configurations[config]`. If there is no such configuration a new one with this name as `type` will be created.
+        },
         build_dir = tostring(Path:new('{cwd}', 'build', '{build_kit}', '{build_type}')), -- Build directory. The expressions `{cwd}`, `{build_kit}` and `{build_type}` will be expanded with the corresponding text values. Could be a function that return the path to the build directory.
         cmake_kits_file = nil, -- set path to JSON file containing cmake kits
         cmake_build_types_file = nil, -- set path to JSON file containing cmake kits
@@ -25,12 +28,18 @@ local config = {
       },
       zig = {
         cmd = 'zig', -- zig command which will be invoked
-        dap_name = 'codelldb', -- DAP configuration name from `require('dap').configurations`. If there is no such configuration, a new one with this name as `type` will be created.
+        dap = {
+          config = 'zig', -- DAP language configurations from `require('dap').configurations`. If there are no such configurations, a new one will be created.
+          name = 'codelldb', -- DAP configuration name from `require('dap').configurations[config]`. If there is no such configuration a new one with this name as `type` will be created.
+        },
         build_type = 'Debug', -- build type, can be changed using `:Task set_module_param zig build_type`
         build_step = 'install', -- build step, cah be changed using `:Task set_module_param zig build_step`
       },
       cargo = {
-        dap_name = 'codelldb', -- DAP configuration name from `require('dap').configurations`. If there is no such configuration, a new one with this name as `type` will be created.
+        dap = {
+          config = 'rust', -- DAP language configurations from `require('dap').configurations`. If there are no such configurations, a new one will be created.
+          name = 'codelldb', -- DAP configuration name from `require('dap').configurations[config]`. If there is no such configuration a new one with this name as `type` will be created.
+        },
       },
       npm = {
         cmd = 'npm', -- npm command which will be invoked. If using yarn or pnpm, change here.

--- a/lua/tasks/module/bazel.lua
+++ b/lua/tasks/module/bazel.lua
@@ -51,7 +51,7 @@ end
 local Bazel = {
   params = {
     'cmd',
-    'dap_name',
+    'dap',
     build_type = { 'fastbuild', 'dbg', 'opt' },
     target = query_bazel_targets,
     'compile_commands_refresh_target',
@@ -169,7 +169,7 @@ local function debug(module_config, _)
     return nil
   end
 
-  command.dap_name = module_config.dap_name
+  command.dap = module_config.dap
   -- note: https://github.com/vadimcn/codelldb/discussions/517#discussioncomment-1331286
   -- Bazel replaces the actual source location with "/proc/self/cwd" in order to achieve repeatable builds.
   -- You'll need to add "sourceMap": { ".": "${workspaceFolder}" } to your launch configuration.

--- a/lua/tasks/module/cargo.lua
+++ b/lua/tasks/module/cargo.lua
@@ -133,7 +133,7 @@ local function debug_test(module_config, previous_job)
 
   return {
     cmd = package.executable,
-    dap_name = module_config.dap_name,
+    dap = module_config.dap,
     errorformat = errorformat,
   }
 end
@@ -161,13 +161,13 @@ local function debug(module_config, previous_job)
 
   return {
     cmd = package.executable,
-    dap_name = module_config.dap_name,
+    dap = module_config.dap,
     errorformat = errorformat,
   }
 end
 
 cargo.params = {
-  'dap_name',
+  'dap',
   'global_cargo_args',
 }
 cargo.condition = function() return Path:new('Cargo.toml'):exists() end

--- a/lua/tasks/module/cmake.lua
+++ b/lua/tasks/module/cmake.lua
@@ -393,7 +393,7 @@ local function debug(module_config, _)
     return nil
   end
 
-  command.dap_name = module_config.dap_name
+  command.dap = module_config.dap
   return command
 end
 
@@ -411,9 +411,11 @@ local function setupCMakeDAP(configure_command)
     },
   }
   dap.configurations.cmake = {
-    type = 'cmake',
-    request = 'attach',
-    name = 'CMake Debugger',
+    {
+      type = 'cmake',
+      request = 'attach',
+      name = 'CMake Debugger',
+    },
   }
 end
 
@@ -425,7 +427,10 @@ local function configureDebug(module_config, _)
 
   setupCMakeDAP(command)
 
-  command.dap_name = 'cmake'
+  command.dap = {
+    config = 'cmake',
+    name = 'cmake',
+  }
   return command
 end
 

--- a/lua/tasks/module/zig.lua
+++ b/lua/tasks/module/zig.lua
@@ -67,7 +67,7 @@ local function debug_file(module_config, _)
   local srcFilename = vim.fn.fnamemodify(currentSource, ':t:r')
   return {
     cmd = '.zig-cache/run-' .. srcFilename,
-    dap_name = module_config.dap_name,
+    dap = module_config.dap,
   }
 end
 
@@ -93,7 +93,7 @@ local function debug_test_file(module_config, _)
   local srcFilename = vim.fn.fnamemodify(currentSource, ':t:r')
   return {
     cmd = '.zig-cache/test-' .. srcFilename,
-    dap_name = module_config.dap_name,
+    dap = module_config.dap,
   }
 end
 
@@ -144,7 +144,7 @@ end
 return {
   params = {
     'cmd',
-    'dap_name',
+    'dap',
     build_type = { 'Debug', 'ReleaseSafe', 'ReleaseFast', 'ReleaseSmall' },
     build_step = get_build_steps,
   },

--- a/lua/tasks/runner.lua
+++ b/lua/tasks/runner.lua
@@ -115,10 +115,11 @@ function runner.chain_commands(task_name, commands, module_config, addition_args
     env = vim.tbl_extend('force', env, vim.tbl_get(module_config, 'env', task_name) or {})
   end
 
-  if command.dap_name then
+  if command.dap then
     vim.schedule(function()
       local dap = require('dap')
-      local dap_config = dap.configurations[command.dap_name] -- Try to get an existing configuration
+      local dap_config = dap.configurations[command.dap.config] -- Try to get an existing configuration
+      dap_config = dap_config[utils.get_dap_index(command.dap.name, dap_config)]
       local dap_config_args = {
         name = command.cmd,
         request = 'launch',
@@ -129,7 +130,7 @@ function runner.chain_commands(task_name, commands, module_config, addition_args
       if command.dap_config then
         dap_config_args = vim.tbl_extend('force', dap_config_args, command.dap_config)
       end
-      dap.run(vim.tbl_extend('force', dap_config and dap_config or { type = command.dap_name }, dap_config_args))
+      dap.run(vim.tbl_extend('force', dap_config and dap_config or { type = command.dap.name }, dap_config_args))
       if config.dap_open_command then
         vim.api.nvim_command('cclose')
         config.dap_open_command()

--- a/lua/tasks/utils.lua
+++ b/lua/tasks/utils.lua
@@ -93,4 +93,17 @@ function utils.get_module(module_type)
   return module, module_type
 end
 
+--- Find the index of a dap config
+--- @param name string name of the config
+--- @param configs table language configs list
+--- @return number: the index of the dap config
+function utils.get_dap_index(name, configs)
+  for idx, conf in ipairs(configs) do
+    if conf.name == name then
+      return idx
+    end
+  end
+  return -1
+end
+
 return utils


### PR DESCRIPTION
Adds support for selecting a configuration out of the list of `dap.configurations[type]`. This allows a user to for example have a dap config for running specific files and one that is used for this plugin.

This also fixes a bug in which the dap configuration was completely overridden (as a tbl_extend of a list with a table overrides the list). The most obvious issue of this was that a user was unable to define the adapter name.

Since the user's dap configuration takes precedence over the plugin's extra_dap_args
(see: https://github.com/Shatur/neovim-tasks/blob/8c2bafe4863c624c23067f91d1498696c14837ae/lua/tasks/runner.lua#L122-L131).
I have decided against the approach of taking the first config in the list proposed in #22 as that would also lead to a breaking change (user config is now respected) and gives less freedom in choosing the config.

This is a breaking change, if that matters.


I have currently only tested this for a cmake project and should be able to also test it on a cargo project in the next few days. I don't have any experience in any other build systems with dap support in this plugin and would leave the testing to someone else if possible.