### PR TITLE
fix(lsp): replace deprecated vim.lsp.stop_client with client:stop()

### DIFF
--- a/lua/tasks/cmake_utils/cmake_utils.lua
+++ b/lua/tasks/cmake_utils/cmake_utils.lua
@@ -249,7 +249,13 @@ local function reconfigureClangd()
       offsetEncoding = { 'utf-8' },
     },
   })
-  vim.lsp.stop_client(vim.lsp.get_clients({ name = 'clangd' }))
+  -- vim.lsp.stop_client(vim.lsp.get_clients({ name = 'clangd' }))
+  local clients = vim.lsp.get_clients({ name = 'clangd' })
+  for _, client in ipairs(clients) do
+    if not client:is_stopped() then
+      client:stop()
+    end
+  end
   vim.defer_fn(function() vim.api.nvim_command('edit') end, 500)
 end
 


### PR DESCRIPTION
This change replaces the deprecated API with the recommended client:stop() method.

Additionally, vim.lsp.get_clients() returns a list of clients, so this update
iterates over all matching clients and stops each one individually.

This prevents runtime warnings and ensures compatibility with future Neovim versions.

<img width="970" height="293" alt="deprecated warn" src="https://github.com/user-attachments/assets/925c8375-24c4-40fa-84a8-9bd3c61e110c" />